### PR TITLE
Feature/forbid to play from last moves

### DIFF
--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -14,6 +14,7 @@ function Board(props) {
                 key={i}
                 value={value}
                 isHighlighted={isHighlighted}
+                isEditableSquare={props.isEditableBoard}
                 onClick={() => props.onClick(i)}
             />
         );

--- a/src/components/GameComponent.js
+++ b/src/components/GameComponent.js
@@ -17,6 +17,7 @@ function GameComponent(props) {
                 <div className="game-board">
                     <Board
                         squares={props.squares}
+                        isEditableBoard={props.isEditableBoard}
                         onClick={props.onClick}
                     />
                 </div>

--- a/src/components/GameContainer.js
+++ b/src/components/GameContainer.js
@@ -45,7 +45,7 @@ function GameContainer() {
     }
 
     function jumpTo(step) {
-        setIsEditableBoard(step == history.length - 1);
+        setIsEditableBoard(step === history.length - 1);
         
         setStepNumber(step);
         setXIsNext((step % 2) === 0);
@@ -130,7 +130,7 @@ function GameContainer() {
             onClick={handleClick}
             isEditableBoard={isEditableBoard}
             toggleSidebar={handleToggleSideBar}
-            historyInfo={{sortedMoves, isAscendingHistory, isHistoryBarOpen}}
+            historyInfo={{sortedMoves, isAscendingHistory, isHistoryBarOpen, stepNumber}}
             jumpTo={jumpTo}
         />
     );

--- a/src/components/GameContainer.js
+++ b/src/components/GameContainer.js
@@ -19,9 +19,11 @@ function GameContainer() {
     const [ xIsNext, setXIsNext ] = useState(true);
     const [ stepNumber, setStepNumber ] = useState(0);
     const [ isAscendingHistory, setIsAscendingHistory ] = useState(true);
-    const [ isHistoryBarOpen, setIsHistoryBarOpen] = useState(true);
+    const [ isHistoryBarOpen, setIsHistoryBarOpen ] = useState(true);
+    const [ isEditableBoard, setIsEditableBoard ] = useState(true);
 
     function handleClick(i) {
+
         const oldHistory = history.slice(0, stepNumber + 1);
         const current = oldHistory[oldHistory.length - 1];
         const squares = [...current.squares];
@@ -43,6 +45,8 @@ function GameContainer() {
     }
 
     function jumpTo(step) {
+        setIsEditableBoard(step == history.length - 1);
+        
         setStepNumber(step);
         setXIsNext((step % 2) === 0);
     }
@@ -124,6 +128,7 @@ function GameContainer() {
             status={status}
             toggleOrder={toggleOrder}
             onClick={handleClick}
+            isEditableBoard={isEditableBoard}
             toggleSidebar={handleToggleSideBar}
             historyInfo={{sortedMoves, isAscendingHistory, isHistoryBarOpen}}
             jumpTo={jumpTo}

--- a/src/components/HistoryBar.js
+++ b/src/components/HistoryBar.js
@@ -12,19 +12,22 @@ function HistoryBar(props) {
             <label>Move #{num}<label className="secondary">row {row}, column {col}</label></label> :
             <label>GAME START</label>;
     }
+
     function renderMoves(moves) {
         return moves.map(move => {
             const description = buildDescription(move);
             const { num } = move; 
             return (
-                <li className="history-move" key={num}>
+                <li 
+                className={ stepNumber === num ? "history-move selected-move" : "history-move" } 
+                key={num}>
                     <button onClick={() => props.jumpTo(num)}>{description}</button>
                 </li>
             );
         });
     }
 
-    const { sortedMoves, isAscendingHistory, isHistoryBarOpen } = props.historyInfo;
+    const { sortedMoves, isAscendingHistory, isHistoryBarOpen, stepNumber } = props.historyInfo;
     const sidebarClass = isHistoryBarOpen ? 'history-bar open' : 'history-bar';
     const historyBarToggleIcon = isHistoryBarOpen ? faAngleDoubleUp : faAngleDoubleDown;
     const renderedMoves = renderMoves(sortedMoves);

--- a/src/components/Square.js
+++ b/src/components/Square.js
@@ -7,7 +7,7 @@ function Square(props) {
         <button 
             className={props.isHighlighted ? "square highlighted": "square"}
             onClick={props.onClick} 
-        >
+            disabled={!props.isEditableSquare}>
             { props.value }
         </button>
     );

--- a/src/css/HistoryBar.css
+++ b/src/css/HistoryBar.css
@@ -108,20 +108,6 @@
     border-radius: 50%;
 }
 
-.history-move button:focus:before, 
-.history-move button:hover:before {
-    background-color: #000;
-}
-
-.history-move button:hover,
-.history-move button:focus {
-    background-color: #000;
-    color: white;
-    font: 16px;
-    outline: none;
-    cursor: pointer;
-}
-
 .history-move button:hover label,
 .history-move button:focus label {
     cursor: pointer;
@@ -129,6 +115,20 @@
 
 .history-move button:active, .history-move button:focus {
     font-weight: bold
+}
+
+.selected-move button:before, 
+.history-move button:hover:before {
+    background-color: #000;
+}
+
+.history-move button:hover,
+.selected-move button {
+    background-color: #000;
+    color: white;
+    font: 16px;
+    outline: none;
+    cursor: pointer;
 }
 
 .history-move label {

--- a/src/css/Square.css
+++ b/src/css/Square.css
@@ -50,6 +50,10 @@
     font-size: 8vw;
 }
 
+.square:not(:disabled):empty {
+    cursor: pointer;
+}
+
 .square.highlighted {
     font-size: 10vw;
     transition: none;


### PR DESCRIPTION
- Forbid to select a new square when previewing old moves.
- Select on the history the current move previewed